### PR TITLE
Implement Function for Downloading Qt Online Installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if(NOT SUBPROJECT)
 
   install(
     FILES
+      cmake/SetupQt.cmake
       cmake/MkdirRecursive.cmake
       cmake/SetupQtConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/SetupQtConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ if(NOT SUBPROJECT)
   install(
     FILES
       cmake/SetupQt.cmake
-      cmake/MkdirRecursive.cmake
       cmake/SetupQtConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/SetupQtConfigVersion.cmake
     DESTINATION lib/cmake/SetupQt

--- a/cmake/MkdirRecursive.cmake
+++ b/cmake/MkdirRecursive.cmake
@@ -1,5 +1,0 @@
-include_guard(GLOBAL)
-
-function(mkdir_recursive DIR_PATH)
-  file(MAKE_DIRECTORY ${DIR_PATH})
-endfunction()

--- a/cmake/SetupQt.cmake
+++ b/cmake/SetupQt.cmake
@@ -5,10 +5,13 @@ include_guard(GLOBAL)
 function(_download_qt_online_installer)
   if(WIN32)
     set(INSTALLER_NAME qt-unified-windows-x64-4.7.0-online.exe)
+    set(INSTALLER_HASH cb2dbc9f8b91a2107406a5cea60a9a6b)
   elseif(APPLE)
     set(INSTALLER_NAME qt-unified-macOS-x64-4.7.0-online.dmg)
+    set(INSTALLER_HASH 40b0c04a94764db4d8ecdf37a7a8436f)
   else()
     set(INSTALLER_NAME qt-unified-linux-x64-4.7.0-online.run)
+    set(INSTALLER_HASH 3b85d14be6e179649f3eb7b92b50ae86)
   endif()
   set(INSTALLER_PATH ${CMAKE_BINARY_DIR}/_deps/${INSTALLER_NAME})
 
@@ -16,6 +19,7 @@ function(_download_qt_online_installer)
     DOWNLOAD
     https://d13lb3tujbc8s0.cloudfront.net/onlineinstallers/${INSTALLER_NAME}
     ${INSTALLER_PATH}
+    EXPECTED_MD5 ${INSTALLER_HASH}
   )
 
   set(QT_ONLINE_INSTALLER_PATH ${INSTALLER_PATH} PARENT_SCOPE)

--- a/cmake/SetupQt.cmake
+++ b/cmake/SetupQt.cmake
@@ -1,0 +1,22 @@
+include_guard(GLOBAL)
+
+# Downloads the Qt online installer to a build directory.
+# This function outputs a `QT_ONLINE_INSTALLER_PATH` variable indicating the location of the downloaded installer.
+function(_download_qt_online_installer)
+  if(WIN32)
+    set(INSTALLER_NAME qt-unified-windows-x64-4.7.0-online.exe)
+  elseif(APPLE)
+    set(INSTALLER_NAME qt-unified-macOS-x64-4.7.0-online.dmg)
+  else()
+    set(INSTALLER_NAME qt-unified-linux-x64-4.7.0-online.run)
+  endif()
+  set(INSTALLER_PATH ${CMAKE_BINARY_DIR}/_deps/${INSTALLER_NAME})
+
+  file(
+    DOWNLOAD
+    https://d13lb3tujbc8s0.cloudfront.net/onlineinstallers/${INSTALLER_NAME}
+    ${INSTALLER_PATH}
+  )
+
+  set(QT_ONLINE_INSTALLER_PATH ${INSTALLER_PATH} PARENT_SCOPE)
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,5 +13,9 @@ endfunction()
 add_cmake_test(
   BuildExampleTest.cmake
   "Build analogclock example"
-  # Add more test cases here.
+)
+
+add_cmake_test(
+  SetupQtTest.cmake
+  "Download Qt online installer"
 )

--- a/test/SetupQtTest.cmake
+++ b/test/SetupQtTest.cmake
@@ -1,0 +1,22 @@
+# Matches everything if not defined
+if(NOT TEST_MATCHES)
+  set(TEST_MATCHES ".*")
+endif()
+
+include(SetupQt)
+
+set(TEST_COUNT 0)
+
+if("Download Qt online installer" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  _download_qt_online_installer()
+
+  if(NOT EXISTS ${QT_ONLINE_INSTALLER_PATH})
+    message(FATAL_ERROR "The downloaded installer does not exist in ${QT_ONLINE_INSTALLER_PATH}")
+  endif()
+endif()
+
+if(TEST_COUNT LESS_EQUAL 0)
+  message(FATAL_ERROR "Nothing to test with: ${TEST_MATCHES}")
+endif()


### PR DESCRIPTION
This pull request resolves #7 by introducing a `_download_qt_online_installer` function inside a new `SetupQt.cmake` module alongside its testing. This function is responsible for downloading a Qt online installer to a build directory. It also removes the sample `MkdirRecursive.cmake` module from this project.