### PR TITLE
Enable Cache for Qt Installation in Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           version: 6.2.4
           dir: ${{ github.workspace }}
+          cache: true
           examples: true
 
       - name: Configure Project


### PR DESCRIPTION
This pull request resolves #9 by simply enabling cache when installing Qt in the `test-project` job of the `test` workflow.