### PR TITLE
Build Example From Cloned Repository

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,6 @@ jobs:
           version: 6.2.4
           dir: ${{ github.workspace }}
           cache: true
-          examples: true
 
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,6 @@ jobs:
         uses: jurplel/install-qt-action@v3.3.0
         with:
           version: 6.2.4
-          dir: ${{ github.workspace }}
           cache: true
 
       - name: Configure Project
@@ -30,5 +29,3 @@ jobs:
 
       - name: Test Project
         run: ctest -C debug --output-on-failure --test-dir build --no-tests=error
-        env:
-          HOME: ${{ github.workspace }}

--- a/test/BuildExampleTest.cmake
+++ b/test/BuildExampleTest.cmake
@@ -8,12 +8,46 @@ set(TEST_COUNT 0)
 if("Build analogclock example" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
 
+  if(NOT EXISTS qtbase)
+    message(STATUS "Cloning analogclock project")
+    execute_process(
+      COMMAND git clone --filter=blob:none --no-checkout https://github.com/qt/qtbase
+      RESULT_VARIABLE RES
+    )
+    if(NOT RES EQUAL 0)
+      message(FATAL_ERROR "Failed to clone analogclock project")
+    endif()
+  endif()
+
+  message(STATUS "Checking out analogclock project")
+  execute_process(
+    COMMAND git -C qtbase sparse-checkout set --cone
+    RESULT_VARIABLE RES
+  )
+  if(NOT RES EQUAL 0)
+    message(FATAL_ERROR "Failed to check out analogclock project")
+  endif()
+  execute_process(
+    COMMAND git -C qtbase checkout 6.2.4
+    RESULT_VARIABLE RES
+  )
+  if(NOT RES EQUAL 0)
+    message(FATAL_ERROR "Failed to check out analogclock project")
+  endif()
+  execute_process(
+    COMMAND git -C qtbase sparse-checkout set examples/gui/analogclock examples/gui/rasterwindow
+    RESULT_VARIABLE RES
+  )
+  if(NOT RES EQUAL 0)
+    message(FATAL_ERROR "Failed to check out analogclock project")
+  endif()
+
   message(STATUS "Reconfiguring analogclock project")
   execute_process(
     COMMAND ${CMAKE_COMMAND}
-      -B ${CMAKE_CURRENT_LIST_DIR}/build/analogclock
+      -B build/analogclock
       --fresh
-      $ENV{HOME}/Qt/Examples/Qt-6.2.4/gui/analogclock
+      qtbase/examples/gui/analogclock
     RESULT_VARIABLE RES
   )
   if(NOT RES EQUAL 0)
@@ -22,7 +56,7 @@ if("Build analogclock example" MATCHES ${TEST_MATCHES})
 
   message(STATUS "Building analogclock project")
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_LIST_DIR}/build/analogclock
+    COMMAND ${CMAKE_COMMAND} --build build/analogclock
     RESULT_VARIABLE RES
   )
   if(NOT RES EQUAL 0)


### PR DESCRIPTION
This pull request resolves #11 by introducing the following changes:
- Modifies the `Build analogclock example` test to build the example project from a cloned repository.
- Modifies the `Install Qt` step in the `test-project` job to install Qt without including examples and install it to the default directory.