### PR TITLE
Utilize GitCheckout.cmake to Check Out Examples

### DIFF
--- a/test/cmake/BuildExampleTest.cmake
+++ b/test/cmake/BuildExampleTest.cmake
@@ -5,41 +5,21 @@ endif()
 
 set(TEST_COUNT 0)
 
+file(
+  DOWNLOAD https://threeal.github.io/git-checkout-cmake/v1.0.0 GitCheckout.cmake
+  EXPECTED_MD5 3f49e8e2318773971d21adb98aa24470
+)
+include(GitCheckout.cmake)
+
 if("Build analogclock example" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
 
   if(NOT EXISTS qtbase)
-    message(STATUS "Cloning analogclock project")
-    execute_process(
-      COMMAND git clone --filter=blob:none --no-checkout https://github.com/qt/qtbase
-      RESULT_VARIABLE RES
+    git_checkout(
+      https://github.com/qt/qtbase
+      REF 6.2.4
+      SPARSE_CHECKOUT examples/gui/analogclock examples/gui/rasterwindow
     )
-    if(NOT RES EQUAL 0)
-      message(FATAL_ERROR "Failed to clone analogclock project")
-    endif()
-  endif()
-
-  message(STATUS "Checking out analogclock project")
-  execute_process(
-    COMMAND git -C qtbase sparse-checkout set --cone
-    RESULT_VARIABLE RES
-  )
-  if(NOT RES EQUAL 0)
-    message(FATAL_ERROR "Failed to check out analogclock project")
-  endif()
-  execute_process(
-    COMMAND git -C qtbase checkout 6.2.4
-    RESULT_VARIABLE RES
-  )
-  if(NOT RES EQUAL 0)
-    message(FATAL_ERROR "Failed to check out analogclock project")
-  endif()
-  execute_process(
-    COMMAND git -C qtbase sparse-checkout set examples/gui/analogclock examples/gui/rasterwindow
-    RESULT_VARIABLE RES
-  )
-  if(NOT RES EQUAL 0)
-    message(FATAL_ERROR "Failed to check out analogclock project")
   endif()
 
   message(STATUS "Reconfiguring analogclock project")


### PR DESCRIPTION
This pull request resolves #15 by utilizing the `git_checkout` function from the `GitCheckout.cmake` module to check out Qt examples.