### PR TITLE
Utilize CTest Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,4 +28,6 @@ jobs:
           options: BUILD_TESTING=ON
 
       - name: Test Project
-        run: ctest -C debug --output-on-failure --test-dir build --no-tests=error
+        uses: threeal/ctest-action@v1.0.0
+        with:
+          build-config: debug


### PR DESCRIPTION
This pull request resolves #23 by using the [CTest Action](https://github.com/marketplace/actions/ctest-action) as a replacement for the `ctest` command to run tests for this project in the GitHub Actions workflows.