### PR TITLE
Allow Spaces in Test Function Names

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,11 @@
 function(add_cmake_test FILE)
   foreach(NAME ${ARGN})
-    string(TOLOWER "${NAME}" TEST_COMMAND)
-    string(REPLACE " " "_" TEST_COMMAND "${TEST_COMMAND}")
     add_test(
       NAME "${NAME}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
         -D CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}
-        -D TEST_COMMAND=${TEST_COMMAND}
+        -D TEST_COMMAND=${NAME}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()

--- a/test/cmake/BuildExampleTest.cmake
+++ b/test/cmake/BuildExampleTest.cmake
@@ -4,7 +4,7 @@ file(
 )
 include(GitCheckout.cmake)
 
-function(test_build_analogclock_example)
+function("Build analogclock example")
   if(NOT EXISTS qtbase)
     git_checkout(
       https://github.com/qt/qtbase
@@ -37,8 +37,8 @@ endfunction()
 
 if(NOT DEFINED TEST_COMMAND)
   message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
-elseif(NOT COMMAND test_${TEST_COMMAND})
-  message(FATAL_ERROR "Unable to find a command named 'test_${TEST_COMMAND}'")
+elseif(NOT COMMAND "${TEST_COMMAND}")
+  message(FATAL_ERROR "Unable to find a command named '${TEST_COMMAND}'")
 endif()
 
-cmake_language(CALL test_${TEST_COMMAND})
+cmake_language(CALL "${TEST_COMMAND}")

--- a/test/cmake/BuildExampleTest.cmake
+++ b/test/cmake/BuildExampleTest.cmake
@@ -35,10 +35,4 @@ function("Build analogclock example")
   endif()
 endfunction()
 
-if(NOT DEFINED TEST_COMMAND)
-  message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
-elseif(NOT COMMAND "${TEST_COMMAND}")
-  message(FATAL_ERROR "Unable to find a command named '${TEST_COMMAND}'")
-endif()
-
 cmake_language(CALL "${TEST_COMMAND}")

--- a/test/cmake/SetupQtTest.cmake
+++ b/test/cmake/SetupQtTest.cmake
@@ -84,10 +84,4 @@ function("Execute Qt online installer")
   endif()
 endfunction()
 
-if(NOT DEFINED TEST_COMMAND)
-  message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
-elseif(NOT COMMAND "${TEST_COMMAND}")
-  message(FATAL_ERROR "Unable to find a command named '${TEST_COMMAND}'")
-endif()
-
 cmake_language(CALL "${TEST_COMMAND}")

--- a/test/cmake/SetupQtTest.cmake
+++ b/test/cmake/SetupQtTest.cmake
@@ -1,6 +1,6 @@
 include(SetupQt)
 
-function(test_download_qt_online_installer)
+function("Download Qt online installer")
   _download_qt_online_installer()
 
   if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
@@ -22,7 +22,7 @@ function(test_download_qt_online_installer)
   endif()
 endfunction()
 
-function(test_attach_and_detach_qt_online_installer)
+function("Attach and detach Qt online installer")
   _download_qt_online_installer()
   _attach_qt_online_installer()
 
@@ -59,8 +59,7 @@ function(test_attach_and_detach_qt_online_installer)
   endif()
 endfunction()
 
-
-function(test_execute_qt_online_installer)
+function("Execute Qt online installer")
   _download_qt_online_installer()
   if(DEFINED QT_ONLINE_INSTALLER_IMAGE)
     _attach_qt_online_installer()
@@ -87,8 +86,8 @@ endfunction()
 
 if(NOT DEFINED TEST_COMMAND)
   message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
-elseif(NOT COMMAND test_${TEST_COMMAND})
-  message(FATAL_ERROR "Unable to find a command named 'test_${TEST_COMMAND}'")
+elseif(NOT COMMAND "${TEST_COMMAND}")
+  message(FATAL_ERROR "Unable to find a command named '${TEST_COMMAND}'")
 endif()
 
-cmake_language(CALL test_${TEST_COMMAND})
+cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request resolves #57 by allowing spaces in the test function names, enabling the test function to have the same name as the test name. This change also removes unnecessary if guards before calling the test command.