### PR TITLE
Specify CMake Minimum Version in Test Modules

### DIFF
--- a/test/cmake/BuildExampleTest.cmake
+++ b/test/cmake/BuildExampleTest.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 file(
   DOWNLOAD https://threeal.github.io/git-checkout-cmake/v1.0.0 GitCheckout.cmake
   EXPECTED_MD5 3f49e8e2318773971d21adb98aa24470

--- a/test/cmake/SetupQtTest.cmake
+++ b/test/cmake/SetupQtTest.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 include(SetupQt)
 
 function(test_download_qt_online_installer)


### PR DESCRIPTION
This pull request resolves #59 by simply specifying the CMake minimum required version in the test modules.