### PR TITLE
Improve Function Arguments Handling

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,12 @@
 function(add_cmake_test FILE)
-  foreach(NAME ${ARGN})
+  math(EXPR STOP "${ARGC} - 1")
+  foreach(I RANGE 1 "${STOP}")
     add_test(
-      NAME "${NAME}"
+      NAME "${ARGV${I}}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
         -D CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}
-        -D TEST_COMMAND=${NAME}
+        -D "TEST_COMMAND=${ARGV${I}}"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()


### PR DESCRIPTION
This pull request resolves #61 by utilizing the `ARGC` and `ARGV<INDEX>` variables in the `add_cmake_test` function.