### PR TITLE
Bump Assertion.cmake to Version 0.3.0

### DIFF
--- a/test/cmake/BuildExampleTest.cmake
+++ b/test/cmake/BuildExampleTest.cmake
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 file(
-  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 4ee0e5217b07442d1a31c46e78bb5fac)
+  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
 file(
@@ -23,13 +23,11 @@ function("Build analogclock example")
 
   message(STATUS "Reconfiguring analogclock project")
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}"
-      -B build/analogclock
-      --fresh
+    "${CMAKE_COMMAND}" -B build/analogclock --fresh
       qtbase/examples/gui/analogclock)
 
   message(STATUS "Building analogclock project")
-  assert_execute_process(COMMAND "${CMAKE_COMMAND}" --build build/analogclock)
+  assert_execute_process("${CMAKE_COMMAND}" --build build/analogclock)
 endfunction()
 
 cmake_language(CALL "${TEST_COMMAND}")

--- a/test/cmake/BuildExampleTest.cmake
+++ b/test/cmake/BuildExampleTest.cmake
@@ -21,13 +21,15 @@ function("Build analogclock example")
     )
   endif()
 
-  message(STATUS "Reconfiguring analogclock project")
-  assert_execute_process(
-    "${CMAKE_COMMAND}" -B build/analogclock --fresh
-      qtbase/examples/gui/analogclock)
+  section("reconfigure analogclock project")
+    assert_execute_process(
+      "${CMAKE_COMMAND}" -B build/analogclock --fresh
+        qtbase/examples/gui/analogclock)
+  endsection()
 
-  message(STATUS "Building analogclock project")
-  assert_execute_process("${CMAKE_COMMAND}" --build build/analogclock)
+  section("build analogclock project")
+    assert_execute_process("${CMAKE_COMMAND}" --build build/analogclock)
+  endsection()
 endfunction()
 
 cmake_language(CALL "${TEST_COMMAND}")

--- a/test/cmake/SetupQtTest.cmake
+++ b/test/cmake/SetupQtTest.cmake
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 file(
-  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 4ee0e5217b07442d1a31c46e78bb5fac)
+  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
 include(SetupQt)
@@ -55,7 +55,7 @@ function("Execute Qt online installer")
   assert(DEFINED QT_ONLINE_INSTALLER_PROGRAM)
   assert(EXISTS "${QT_ONLINE_INSTALLER_PROGRAM}")
 
-  assert_execute_process(COMMAND "${QT_ONLINE_INSTALLER_PROGRAM}" --version)
+  assert_execute_process("${QT_ONLINE_INSTALLER_PROGRAM}" --version)
 
   if(DEFINED QT_ONLINE_INSTALLER_VOLUME)
     _detach_qt_online_installer()


### PR DESCRIPTION
This pull request bumps the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module to version [0.3.0](https://github.com/threeal/assertion-cmake/releases/tag/v0.3.0). It also modifies tests to utilize the `section` function for debugging the current test section that is running.