### PR TITLE
Add Option to Enable Install Targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,17 @@ project(
   LANGUAGES NONE
 )
 
+option(SETUP_QT_ENABLE_INSTALL "Enable install targets."
+  "${PROJECT_IS_TOP_LEVEL}")
+
 include(cmake/SetupQt.cmake)
 
-if(PROJECT_IS_TOP_LEVEL)
-  if(BUILD_TESTING)
-    enable_testing()
-    add_subdirectory(test)
-  endif()
+if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(test)
+endif()
 
+if(SETUP_QT_ENABLE_INSTALL)
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
     SetupQtConfigVersion.cmake


### PR DESCRIPTION
This pull request resolves #71 by adding a `SETUP_QT_ENABLE_INSTALL` option to enable install targets in the project. By default, this option is enabled if the `PROJECT_IS_TOP_LEVEL` variable is also enabled.