### PR TITLE
Bump Assertion.cmake to Version 1.0.0

### DIFF
--- a/test/cmake/BuildExampleTest.cmake
+++ b/test/cmake/BuildExampleTest.cmake
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 file(
-  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
+  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
 file(

--- a/test/cmake/SetupQtTest.cmake
+++ b/test/cmake/SetupQtTest.cmake
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 file(
-  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
+  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
 find_package(SetupQt REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../../cmake)


### PR DESCRIPTION
This pull request bumps the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module to version [1.0.0](https://github.com/threeal/assertion-cmake/releases/tag/v1.0.0).