### PR TITLE
Remove Upload Project Step in CI Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,3 @@ jobs:
 
       - name: Install Project
         run: cmake --install build --prefix install
-
-      - name: Upload Project as Artifact
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          path: install


### PR DESCRIPTION
This pull request resolves #110 by removing the step that uploads the project as an artifact from the CI workflows.